### PR TITLE
feat: cache python packages for speedup(DOCKER_BUILDKIT=1)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bookworm
+FROM python:3.12-slim-bookworm
 
 RUN apt-get update && apt-get install -y curl procps && \
     apt-get clean && \
@@ -6,8 +6,8 @@ RUN apt-get update && apt-get install -y curl procps && \
 
 COPY requirements.txt /
 
-RUN \
-  python3 -m pip install -r requirements.txt && rm -rf ~/.cache && rm requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip \
+  python3 -m pip install -r requirements.txt && rm requirements.txt
 
 ADD /ex_app/cs[s] /ex_app/css
 ADD /ex_app/im[g] /ex_app/img

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,29 @@
-FROM python:3.12-slim-bookworm
+#############################
+# Stage 1: Builder
+#############################
+FROM python:3.12-slim-bookworm AS builder
 
-RUN apt-get update && apt-get install -y curl procps && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+# Install build dependencies
+RUN apt-get update && apt-get install -y curl && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# Copy requirements and install Python dependencies using a cache mount.
 COPY requirements.txt /
-
 RUN --mount=type=cache,target=/root/.cache/pip \
-  python3 -m pip install -r requirements.txt && rm requirements.txt
+    python3 -m pip install -r requirements.txt && rm requirements.txt
 
+# Add application files (using your ADD patterns)
 ADD /ex_app/cs[s] /ex_app/css
 ADD /ex_app/im[g] /ex_app/img
 ADD /ex_app/j[s] /ex_app/js
 ADD /ex_app/l10[n] /ex_app/l10n
 ADD /ex_app/li[b] /ex_app/lib
 
+# Copy scripts with the proper permissions.
 COPY --chmod=775 healthcheck.sh /
 COPY --chmod=775 start.sh /
 
-# Download and install FRP client
+# Download and install FRP client into /usr/local/bin.
 RUN set -ex; \
     ARCH=$(uname -m); \
     if [ "$ARCH" = "aarch64" ]; then \
@@ -34,6 +39,23 @@ RUN set -ex; \
     chmod +x /usr/local/bin/frpc; \
     rm -rf /tmp/frp /tmp/frp.tar.gz
 
+#############################
+# Stage 2: Final Runtime Image
+#############################
+FROM python:3.12-slim-bookworm
+
+# Install any runtime apt packages your app needs.
+RUN apt-get update && apt-get install -y curl procps && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Copy installed Python packages and FRP client from the builder.
+COPY --from=builder /usr/local/ /usr/local/
+# Copy application files and scripts from the builder.
+COPY --from=builder /ex_app/ /ex_app/
+COPY --from=builder /healthcheck.sh /healthcheck.sh
+COPY --from=builder /start.sh /start.sh
+
+# Set working directory and define entrypoint/healthcheck.
 WORKDIR /ex_app/lib
 ENTRYPOINT ["/start.sh"]
 HEALTHCHECK --interval=2s --timeout=2s --retries=300 CMD /healthcheck.sh

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ help:
 .PHONY: build-push
 build-push:
 	docker login ghcr.io
-	docker buildx build --push --platform linux/arm64/v8,linux/amd64 --tag ghcr.io/nextcloud/app-skeleton-python:latest .
+	DOCKER_BUILDKIT=1 docker buildx build --push --platform linux/arm64/v8,linux/amd64 --tag ghcr.io/nextcloud/app-skeleton-python:latest .
 
 .PHONY: run30
 run29:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-nc_py_api[app]>=0.19.1
+nc_py_api[app]>=0.19.2


### PR DESCRIPTION
Instead of downloading packages for ExApp in python every time, we can ask docker to keep them in a separate volume and use from there. (not much speed for skeleton, but for any program that uses PyTorch it is a huge plus)

What do you think about it?


Edited: Also changed Docker file to use stage build - to allow use this in GitHub Actions without modification.