### PR TITLE
feat: easier HaRP adopt - modified start.sh to accept an entrypoint arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,5 +53,5 @@ COPY --chmod=775 start.sh /
 
 # Set working directory and define entrypoint/healthcheck.
 WORKDIR /ex_app/lib
-ENTRYPOINT ["/start.sh"]
+ENTRYPOINT ["/start.sh", "python3", "main.py"]
 HEALTHCHECK --interval=2s --timeout=2s --retries=300 CMD /healthcheck.sh

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ help:
 
 .PHONY: build-push
 build-push:
-	docker login ghcr.io
+    # docker login ghcr.io
 	DOCKER_BUILDKIT=1 docker buildx build --push --platform linux/arm64/v8,linux/amd64 --tag ghcr.io/nextcloud/app-skeleton-python:latest .
 
 .PHONY: run30

--- a/start.sh
+++ b/start.sh
@@ -60,6 +60,6 @@ if [ -f /frpc.toml ] && [ -n "$HP_SHARED_KEY" ]; then
     frpc -c /frpc.toml &
 fi
 
-# Start the main application (adjust it for your ExApp)
-echo "Starting main application..."
-exec python3 main.py
+# Start the main application (launch cmd for ExApp is an argument for this script)
+echo "Starting application: $@"
+exec "$@"


### PR DESCRIPTION
Now `start.sh` script just accepts string which it should execute at the end.

Much more easy maintenance work: this allows to just copy and paste `start.sh` script for HaRP for ExApps without modifying it at all.